### PR TITLE
Remove newline that breaks script execution and fix thread local vars

### DIFF
--- a/Python_Objects.Patch
+++ b/Python_Objects.Patch
@@ -1,0 +1,14 @@
+diff -Naur tmp/Python-2.7.13/Objects/object.c Python-2.7.13/Objects/object.c
+--- tmp/Python-2.7.13/Objects/object.c	2018-09-04 16:09:34.000000000 -0400
++++ Python-2.7.13/Objects/object.c	2018-09-04 16:07:37.000000000 -0400
+@@ -29,8 +29,8 @@
+ }
+ #endif /* Py_REF_DEBUG */
+ 
+-int Py_DivisionWarningFlag;
+-int Py_Py3kWarningFlag;
++__thread int Py_DivisionWarningFlag;
++__thread int Py_Py3kWarningFlag;
+ 
+ /* Object allocation routines used by NEWOBJ and NEWVAROBJ macros.
+    These are used by the individual routines for object creation.

--- a/getPackages.sh
+++ b/getPackages.sh
@@ -23,8 +23,7 @@ rm libffi-3.2.1.tar.gz
 echo "Applying patch to libffi-3.2.1:"
 (cd libffi-3.2.1 ; patch -p 1 < ../libffi-3.2.1_patch ; cd ..)
 echo "Compiling libffi-3.2.1:"
-(cd libffi-3.2.1 ;  xcodebuild -project libffi.xcodeproj -target libffi-iOS -sdk iphoneos -arch arm64 -configuration Debug -quiet
-; mv build/Debug-iphoneos/libffi.a .. ; cd ..)
+(cd libffi-3.2.1 ;  xcodebuild -project libffi.xcodeproj -target libffi-iOS -sdk iphoneos -arch arm64 -configuration Debug -quiet; mv build/Debug-iphoneos/libffi.a .. ; cd ..)
 echo "Applying patches to Python-2.7.13"
 (cd Python-2.7.13 ; patch -p 1 < ../Python_Include.patch ; patch -p 1 < ../Python_Lib.patch ; patch -p 1 < ../Python_Modules.patch; patch -p 1 < ../Python_Parser.patch ; patch -p 1 < ../Python_Python.patch; patch -p 1 < ../Python_setup.patch ; cd ..)
 

--- a/getPackages.sh
+++ b/getPackages.sh
@@ -10,14 +10,14 @@ curl -OL https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz
 tar -xvzf Python-2.7.13.tgz
 rm Python-2.7.13.tgz
 echo "Downloading ios_system.framework"
-(cd Frameworks 
+(cd Frameworks
 curl -OL $HHROOT/ios_system/releases/download/v$IOS_SYSTEM_VER/smallRelease.tar.gz
 ( tar -xzf smallRelease.tar.gz --strip 1 && rm smallRelease.tar.gz ) || { echo "ios_system failed to download"; exit 1; }
 )
 echo "Downloading header file:"
-curl -OL $HHROOT/ios_system/releases/download/v$IOS_SYSTEM_VER/ios_error.h 
-echo "Downloading libffi-3.2.1" 
-curl -OL https://www.mirrorservice.org/sites/sourceware.org/pub/libffi/libffi-3.2.1.tar.gz 
+curl -OL $HHROOT/ios_system/releases/download/v$IOS_SYSTEM_VER/ios_error.h
+echo "Downloading libffi-3.2.1"
+curl -OL https://www.mirrorservice.org/sites/sourceware.org/pub/libffi/libffi-3.2.1.tar.gz
 tar -xvzf libffi-3.2.1.tar.gz
 rm libffi-3.2.1.tar.gz
 echo "Applying patch to libffi-3.2.1:"
@@ -25,8 +25,8 @@ echo "Applying patch to libffi-3.2.1:"
 echo "Compiling libffi-3.2.1:"
 (cd libffi-3.2.1 ;  xcodebuild -project libffi.xcodeproj -target libffi-iOS -sdk iphoneos -arch arm64 -configuration Debug -quiet; mv build/Debug-iphoneos/libffi.a .. ; cd ..)
 echo "Applying patches to Python-2.7.13"
-(cd Python-2.7.13 ; patch -p 1 < ../Python_Include.patch ; patch -p 1 < ../Python_Lib.patch ; patch -p 1 < ../Python_Modules.patch; patch -p 1 < ../Python_Parser.patch ; patch -p 1 < ../Python_Python.patch; patch -p 1 < ../Python_setup.patch ; cd ..)
+(cd Python-2.7.13 ; patch -p 1 < ../Python_Include.patch ; patch -p 1 < ../Python_Lib.patch ; patch -p 1 < ../Python_Modules.patch; patch -p 1 < ../Python_Parser.patch ; patch -p 1 < ../Python_Python.patch; patch -p 1 < ../Python_setup.patch ; patch -p 1 < ../Python_Objects.patch; cd ..)
 
 echo "All done. Now open Python_ios.xcodeproj and compile."
- 
+
 


### PR DESCRIPTION
This PR corrects a typo (extraneous newline) in the getPackages script that breaks the setup process.